### PR TITLE
Enable giscus comments on blog posts

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -21,6 +21,17 @@ defaultContentLanguage = "en"
   favicon_32 = "/img/favicon-32x32.png"
   favicon_16 = "/img/favicon-16x16.png"
 
+[params.giscus]
+  repo = "Blokje5/blokje5.dev"
+  repoID = "MDEwOlJlcG9zaXRvcnkxOTUyOTA2NDE="
+  category = "Announcements"
+  categoryID = "DIC_kwDOC6PmEc4DBP-j"
+  theme = "preferred_color_scheme"
+  mapping = "pathname"
+  reactionsEnabled = "1"
+  inputPosition = "top"
+  lang = "en"
+
 [taxonomies]
   category = "categories"
   series = "series"


### PR DESCRIPTION
Adds `[params.giscus]` to `hugo.toml`. The hugo-coder theme already renders a giscus partial in every post footer when `giscus.repo` is set, so this is config-only — no template changes.

## What this does
- Renders a giscus-backed comment section on all posts.
- Maps discussions by `pathname` into the **Announcements** category (maintainer-only, so per-post discussions are created on demand by giscus at first comment).
- Sets `theme = "preferred_color_scheme"` so comments match the visitor's OS light/dark preference on first load; manual theme toggles still override it.

## Prerequisites done outside this diff
- GitHub Discussions enabled on the repo.
- giscus GitHub App installed on the repo.

## Verification
- `hugo --minify` builds clean.
- The giscus `<script>` with the correct repo, category, and mapping attributes renders in all posts.

Per-post opt-out remains available via `disableComments: true` in front matter.